### PR TITLE
Fixed zombie left after fork - this time for real

### DIFF
--- a/src/connman.c
+++ b/src/connman.c
@@ -382,7 +382,7 @@ int connman() {
 			if (ev.type == ButtonPress) {
 				XButtonEvent* xbv = (XButtonEvent*) &ev;
 				if (xbv->button == 1 && connman_click[0]) {
-					// use a double fork to creating a zombie process
+					// use a double fork to avoid creating a zombie process
 					pid_t pid1;
 					pid_t pid2;
 					int status;


### PR DESCRIPTION
Sorry about this, but my last "fix" was not a real fix.  All it did was change the names so they did not appear in the filtered HTOP output that I was looking at.

From what I can determine the proper fix is to use a double fork, which is what is implemented in this PR.  I've had this running for several hours, starting and stopping the process repeatedly using the mouse clicks, and reviewed the full HTOP output looking for any zombies.   I do believe that this time I've got it.
