### PR TITLE
Battery module with notification support

### DIFF
--- a/src/battery.c
+++ b/src/battery.c
@@ -90,7 +90,6 @@ static void sendNotification(int percentfull)
 	unsigned char val00= 0;
 	const char* key01 = "category";
 	const char* val01 = "device";	
-	
 
 	// create the summary, app_icon, body text and urgency level
 	if (percentfull <= notification_trigger) {
@@ -122,8 +121,7 @@ static void sendNotification(int percentfull)
 	msg = dbus_message_new_method_call("org.freedesktop.Notifications", // target for the method call
 																		"/org/freedesktop/Notifications", // object to call on
 																		"org.freedesktop.Notifications", // interface to call on
-																		"Notify"); // method name
-																																			
+																		"Notify"); // method name																															
 	
 	// assemble the arguments for the method call	
 	dbus_message_iter_init_append(msg, &iter00);
@@ -220,6 +218,7 @@ static int rescan() {
 			++n_bat;		
 		udev_device_unref(dev);
 	}	// foreach	
+	
 	// Make sure there are enough icons to cover the number of batteries found
 	if (n_bat > sizeof(bat)/sizeof(bat[0])) {
 		fprintf(stderr, "Error: found %i batteries, but only %i icons are defined\n",n_bat, sizeof(bat)/sizeof(bat[0]));

--- a/src/config.h
+++ b/src/config.h
@@ -77,6 +77,12 @@ static Battery bat[] = {
 // of the icon below.
 static const XRectangle battery_fill_rect = {3, 2, 7, 10};
 
+// Notification Trigger.  Use a negative number for no notifications,
+// or an integer between 0 and 100 representing the percent of charge to
+// trigger notifications. This variable may be supplied even if there is
+// no notification server running on your machine.
+static short notification_trigger = 10;
+
 // 13x13 battery (hollow) icon
 static const XPoint battery_icon_size = { 13, 13 };
 static const char battery_icon_data[] = {


### PR DESCRIPTION
This pull updates the battery module to provide notification support.  If you've got a notification server running you can now set a battery level in config.h that will trigger a notification.  I've also expanded the button clicks on the icon so that a right mouse button click will use the notification server to display the current battery level. 

It is really not hard to send simple notifications directly to the server via DBus, so there is no additional dependency on libnotify.  Adds maybe a few lines to the code, but I prefer to avoid additional dependencies when I can.  If I had used libnotify a lot of the lines would be there anyway just organizing the data to send.

I think the notify function is written in such a way that it could be easily reused for other things, for instance your mail module should you feel so inclined.  I think that is about it for this module, I really don't think I can jam anything else into a 13x13 icon.    
