### PR TITLE
Handle SIGCHLD in blueplate.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 
 PROG     =  blueplate
 MODULES  ?= desktop mail
-#MODULES  += connman
-#MODULES  += battery
+MODULES  += connman
+MODULES  += battery
 VER      =  0.1
 CC       ?= gcc
 MODDEFS  =  $(foreach mod, ${MODULES}, -Dmodule_${mod})
 DEFS     =  -Dprogram_name=${PROG} -Dprogram_ver=${VER} ${MODDEFS}
 DEPS     =  x11
-#DEPS     += dbus-1
+DEPS     += dbus-1
 CFLAGS   += $(shell pkg-config --cflags ${DEPS}) ${DEFS}
 LDLIBS   += $(shell pkg-config --libs ${DEPS}) -lm
 LDLIBS		+=-ludev

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 
 PROG     =  blueplate
 MODULES  ?= desktop mail
-MODULES  += connman
-MODULES  += battery
+#MODULES  += connman
+#MODULES  += battery
 VER      =  0.1
 CC       ?= gcc
 MODDEFS  =  $(foreach mod, ${MODULES}, -Dmodule_${mod})
 DEFS     =  -Dprogram_name=${PROG} -Dprogram_ver=${VER} ${MODDEFS}
 DEPS     =  x11
-DEPS     += dbus-1
+#DEPS     += dbus-1
 CFLAGS   += $(shell pkg-config --cflags ${DEPS}) ${DEFS}
 LDLIBS   += $(shell pkg-config --libs ${DEPS}) -lm
 LDLIBS		+=-ludev

--- a/src/blueplate.c
+++ b/src/blueplate.c
@@ -54,7 +54,24 @@ int init_atoms() {
 }
 
 void sighandler(int sig) {
-	if (sig == SIGTERM) running = False;
+	
+	switch (sig) {
+		case SIGTERM: {
+			running = False;
+			break;
+		}
+		case SIGCHLD: {
+			// we don't use pid or status for anything, but they are here if we want them
+			pid_t pid;
+			int status;
+			
+			pid = waitpid(-1, &status, NULL);
+			break;
+		}	
+		default: 
+			break;
+	}	// switch
+	
 }
 
 void help() {
@@ -87,6 +104,7 @@ int main(int argc, const char **argv) {
 		if (child && (fork() == 0) ) {
 			setsid();
 			sigaction(SIGTERM, &sa, NULL);
+			sigaction(SIGCHLD, &sa, NULL);
 			return child();
 		}
 	}

--- a/src/connman.c
+++ b/src/connman.c
@@ -377,25 +377,13 @@ int connman() {
 			if (ev.type == ButtonPress) {
 				XButtonEvent* xbv = (XButtonEvent*) &ev;
 				if (xbv->button == 1 && connman_click[0]) {
-					// use a double fork to avoid creating a zombie process
 					pid_t pid1;
-					pid_t pid2;
-					int status;
 					if ( (pid1 = fork()) < 0 )
 						fprintf (stderr, "Couldn't fork the a child process to execute %s\n", connman_click[0]);
-					else if (pid1 == 0) {
-						struct sigaction sa;
-						sa.sa_handler = SIG_DFL;
-						sigemptyset(&sa.sa_mask);
-						sigaction(SIGTERM, &sa, NULL);
-						XCloseDisplay(dpy);
-						fclose(stdin);
-						fclose(stdout);
-						fclose(stderr);
-						execvp(connman_click[0], (char * const *) connman_click);
-					}
-					else
-						waitpid(pid1, NULL, WNOHANG);
+					else {
+						if (pid1 == 0)
+							execvp(connman_click[0], (char * const *) connman_click);
+					}	// else we could fork
 				}	// if button 1
 				else running = FALSE;
 			}	// if button press			
@@ -405,4 +393,3 @@ int connman() {
 	xlib_free();
 	return 0;
 }
-


### PR DESCRIPTION
This is a continuation of the discussion we had in #6 about not needing a double fork to avoid creating zombie processes when the forked child is terminated.  I went back to your first suggestion, but I needed to add lines into Blueplate.c to handle the SIGCHLD signal.

I'm very nervous about messing around in your stuff so if you do pull it please look it over carefully first.  I've tested with opening and then killing Blueplate and the child process in every possible order  and multiple times and I'm not seeing any zombie processes left.  
